### PR TITLE
Allow filters in assign statement

### DIFF
--- a/lib/liquid/tags/assign.rb
+++ b/lib/liquid/tags/assign.rb
@@ -9,7 +9,7 @@ module Liquid
   #  {{ foo }}
   #
   class Assign < Tag
-    Syntax = /(#{VariableSignature}+)\s*=\s*(#{QuotedFragment}+)/
+    Syntax = /(#{VariableSignature}+)\s*=\s*(.*)\s*/o
 
     def initialize(tag_name, markup, tokens, context)
       if markup =~ Syntax
@@ -23,7 +23,7 @@ module Liquid
     end
 
     def render(context)
-       context.scopes.last[@to] = context[@from]
+       context.scopes.last[@to] = Liquid::Variable.new(@from).render(context)
        ''
     end
 

--- a/spec/integration/assign_spec.rb
+++ b/spec/integration/assign_spec.rb
@@ -13,6 +13,14 @@ describe "Liquid Rendering" do
         }
       end
 
+      describe %!"{% assign foo = values | first %}.{{ foo }}."! do
+        it{ template.render(render_options).should == '.foo.' }
+      end
+
+      describe %!"{% assign foo = values | first | capitalize %}.{{ foo }}."! do
+        it{ template.render(render_options).should == '.Foo.' }
+      end
+
       describe %|"{% assign foo = values %}.{{ foo[0] }}."| do
         it{ template.render(render_options).should == ".foo." }
       end


### PR DESCRIPTION
Slightly different than the shopify/liquid fix for the same issue; had to create the variable in the render method.
