### PR TITLE
Added the split filter into the standard filters

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -47,6 +47,16 @@ module Liquid
       wordlist.length > l ? wordlist[0..l].join(" ") + truncate_string : input
     end
 
+    # Split input string into an array of substrings separated by given pattern.
+    #
+    # {% assign colors = "Red|Blue|Green" | split: '|' %}
+    # {% for color in colors %}
+    #   Color: {{ color }}
+    # {% endfor %}
+    def split(input, pattern)
+      input.split(pattern)
+    end
+
     def strip_html(input)
       input.to_s.gsub(/<script.*?<\/script>/, '').gsub(/<.*?>/, '')
     end

--- a/spec/unit/filter_spec.rb
+++ b/spec/unit/filter_spec.rb
@@ -88,6 +88,12 @@ module Liquid
       end
     end
 
+    context "#split" do
+      it "should split the given string into an array based on the given delimeter" do
+        filters.split("red|green|blue", "|").should == ['red', 'green', 'blue']
+      end
+    end
+
     context "#strip_html" do
       it "should strip out the html tags but leave the content" do
         filters.strip_html("<div>test</div>").should == "test"


### PR DESCRIPTION
This is in response to locomotive engine issue #557.

I needed the ability to split strings that were coming in from a remote source by a given delimiter.

This ability exists in the liquid template engine it just wasn't ported into your locomotive-liquid lib.
