### PR TITLE
Encode UTF-8 before joining output array

### DIFF
--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -96,7 +96,11 @@ module Liquid
         end
       end
 
-      output.join
+      # Prevent the following error:
+      #   Encoding::CompatibilityError: incompatible character encodings: ASCII-8BIT and UTF-8
+      utf8_ouput = output.map { |str| str.encode(Encoding::UTF_8, invalid: :replace, undef: :replace, replace: "") }
+
+      utf8_ouput.join("")
     end
 
     private


### PR DESCRIPTION
From time to time we have errors like this:

```
Encoding::CompatibilityError: incompatible character encodings: ASCII-8BIT and UTF-8
```

With the following backtrace:

```

locomotivecms-liquid-4.0.0/lib/liquid/block_body.rb:99 → join
locomotivecms-liquid-4.0.0/lib/liquid/block_body.rb:99 → render
locomotivecms-liquid-4.0.0/lib/liquid/block.rb:15 → render
.bundle/ruby/2.3.0/bundler/gems/steam-a9590210629c/lib/locomotive/steam/liquid/tags/extends.rb:10 → block in render
locomotivecms-liquid-4.0.0/lib/liquid/context.rb:128 → stack
.bundle/ruby/2.3.0/bundler/gems/steam-a9590210629c/lib/locomotive/steam/liquid/tags/extends.rb:8 → render
locomotivecms-liquid-4.0.0/lib/liquid/block_body.rb:105 → render_token
locomotivecms-liquid-4.0.0/lib/liquid/block_body.rb:87 → block in render
locomotivecms-liquid-4.0.0/lib/liquid/block_body.rb:74 → each
locomotivecms-liquid-4.0.0/lib/liquid/block_body.rb:74 → render
locomotivecms-liquid-4.0.0/lib/liquid/template.rb:215 → block in render
locomotivecms-liquid-4.0.0/lib/liquid/template.rb:269 → with_profiling
locomotivecms-liquid-4.0.0/lib/liquid/template.rb:214 → render
.bundle/ruby/2.3.0/bundler/gems/steam-a9590210629c/lib/locomotive/steam/liquid/template.rb:17 → render
.bundle/ruby/2.3.0/bundler/gems/steam-a9590210629c/lib/locomotive/steam/middlewares/renderer.rb:40 → parse_and_render_liquid
.bundle/ruby/2.3.0/bundler/gems/steam-a9590210629c/lib/locomotive/steam/middlewares/renderer.rb:22 → render_page
.bundle/ruby/2.3.0/bundler/gems/steam-a9590210629c/lib/locomotive/steam/middlewares/renderer.rb:10 → _call
.bundle/ruby/2.3.0/bundler/gems/steam-a9590210629c/lib/locomotive/steam/middlewares/thread_safe.rb:13 → call
.bundle/ruby/2.3.0/bundler/gems/steam-a9590210629c/lib/locomotive/steam/middlewares/thread_safe.rb:23 → next
.bundle/ruby/2.3.0/bundler/gems/steam-a9590210629c/lib/locomotive/steam/middlewares/thread_safe.rb:18 → call
.bundle/ruby/2.3.0/bundler/gems/steam-a9590210629c/lib/locomotive/steam/middlewares/thread_safe.rb:23 → next
.bundle/ruby/2.3.0/bundler/gems/steam-a9590210629c/lib/locomotive/steam/middlewares/thread_safe.rb:18 → call
.bundle/ruby/2.3.0/bundler/gems/engine-1cd142815ca1/lib/locomotive/steam/middlewares/cache.rb:31 → fetch_cached_response
.bundle/ruby/2.3.0/bundler/gems/engine-1cd142815ca1/lib/locomotive/steam/middlewares/cache.rb:17 → call
```

According to errbit, it happens only with IE 6, unfortunately I've falied to reproduce it... but this patch is suppose to fix it.

You can accept this PR or decline. It's up to you:)
